### PR TITLE
fix missing AC/L1/Voltage voltage for 1-phase SolarEdge inverters

### DIFF
--- a/software/src/sunspec_updater.cpp
+++ b/software/src/sunspec_updater.cpp
@@ -453,7 +453,11 @@ bool SunspecUpdater::parsePowerAndVoltage(QVector<quint16> values)
 			// sunspec does not provide a voltage for the system as a whole. This does not
 			// make a lot of sense. Since previous versions of dbus-fronius published this
 			// value (retrieved via the Solar API) we use the value from phase 1.
-			cid.acVoltage = getScaledValue(values, 10, 1, 13, false);
+			cid.acVoltage = getScaledValue(values, 10, 1, 13, false);		// I_AC_VoltageAN
+			// Single-phase SolarEdge inverters may use I_AC_VoltageAB instead of I_AC_VoltageAN
+			if (std::isnan(cid.acVoltage)) {
+				cid.acVoltage = getScaledValue(values, 7, 1, 13, false);	// I_AC_VoltageAB
+			}
 			cid.totalEnergy = getScaledValue(values, 24, 2, 26, false);
 			mDataProcessor->process(cid);
 


### PR DESCRIPTION
Single-phase SolarEdge inverters such as the SE3000 report the AC voltage in I_AC_VoltageAB instead of I_AC_VoltageAN, so use that when the latter register is invalid (0xffff).