### PR TITLE
Fix stale LimiterSupported setting when a PV inverter stops supporting model 123/704

### DIFF
--- a/software/src/inverter_mediator.cpp
+++ b/software/src/inverter_mediator.cpp
@@ -221,6 +221,15 @@ void InverterMediator::startAcquisition()
 			mInverter->setLimiterModel(mDeviceInfo.immediateControlModel);
 		}
 
+		// If no limiter object was created, detection didn't find model 123/704
+		// this time. onLimiterDetected() is the only other place that updates
+		// LimiterSupported, and it's only reachable via limiter->onConnected(),
+		// so without this it stays stuck at whatever a previous detection set
+		// it to (e.g. a device that used to support limiting and no longer does).
+		if (limiter == 0) {
+			mInverterSettings->setLimiterSupported(LimiterDisabled);
+		}
+
 		if (mDeviceInfo.retrievalMode == ProtocolSunSpec2018) {
 			qInfo() << "Using protocol IEEE1547-2018";
 			Sunspec2018Updater *updater = new Sunspec2018Updater(


### PR DESCRIPTION
## Problem

  `Settings/Fronius/Inverters/<id>/LimiterSupported` can get permanently stuck at `LimiterEnabled`/`LimiterForcedEnabled` even after an inverter genuinely stops supporting SunSpec model 123/704 power limiting (e.g. a device that briefly supported it during development/testing, or a firmware change that removes the capability). The stale value survives service restarts and full GX device reboots.

  ## Root cause

  `InverterMediator::startAcquisition()` only constructs a `BaseLimiter` when detection reports `immediateControlModel` as `123` or `704`:

  ```cpp
  BaseLimiter *limiter = 0;
  ...
  switch (mDeviceInfo.immediateControlModel) {
  case 123: limiter = new SunspecLimiter(mInverter); break;
  case 704: limiter = new Sunspec2018Limiter(mInverter); break;
  }
  ```

  `mInverter->setLimiterModel(...)` (the *live* `Info/LimiterModel` dbus item) is published unconditionally right after, so it's always accurate.

  But `LimiterSupported` (the *persisted* settings mirror, read by the GUI's `PageSettingsFroniusInverter.qml` to decide whether to show the "Dynamic power limiting" control) is only ever written from `SunspecUpdater::onLimiterDetected()`:

  ```cpp
  if (success) {
      ...
      mSettings->setLimiterSupported(LimiterEnabled); // or LimiterForcedEnabled
  } else {
      mSettings->setLimiterSupported(LimiterDisabled);
  }
  ```

  That function is only reachable through `limiter->onConnected()` (`SunspecUpdater::onConnected()`'s `if (mLimiter) { ... }` branch). When `limiter` is null — i.e. detection found no model 123/704 this time — that whole code path is skipped, so `LimiterSupported` is never touched and just keeps whatever value a previous detection (possibly from different firmware, possibly weeks ago) left it at.

  ## Fix

  Add the missing clear, right after the existing limiter-selection block in `startAcquisition()`:

  ```cpp
  if (limiter == 0) {
      mInverterSettings->setLimiterSupported(LimiterDisabled);
  }
  ```

  This mirrors exactly what `onLimiterDetected(false)` already does for the "limiter object exists but detection failed" case — it just covers the "no limiter object was even created" case, which was the actual gap.

  `startAcquisition()` is the right place: it's the single point where a freshly detected `DeviceInfo` gets turned into both a limiter object and persisted settings, it runs on every reconnect via `processNewInverter()` *and* on first-boot via `onSettingsInitialized()` (which calls straight into it), and `mDeviceInfo.immediateControlModel` is already known synchronously by this point — no new state, no new signal
  wiring, no timing/race concerns.

  ## Scope / risk

  - 9 lines, one file, no behavior change for any inverter that *does* have a limiter (SolarEdge, SMA, generic SunSpec 123/704 paths are all untouched).
  - Only affects the case where `limiter` stays null — previously a silent no-op, now correctly clears the setting.
  - `EnableLimiter` (the user's own "please enable it" preference) is left alone deliberately — it's inert while `LimiterSupported=0` (the QML gates the whole control on `LimiterSupported == 1`), and preserving it means a device that regains limiter support later doesn't need the user to re-enable it.

  ## Testing

  Reproduced and verified fix on real hardware:
  - Custom OpenDTU-based SunSpec/Modbus TCP server, briefly ran with model 123 support, then rebuilt without it.
  - Before fix: `Settings/Fronius/.../LimiterSupported` stuck at `1` across multiple GX device reboots, while `Info/LimiterModel` correctly showed `0` live the whole time (confirming detection itself was fine, only the persisted setting was stale).
  - Cross-compiled this patch against the `venus-scarthgap` v1.7.28 SDK (Cortex-A8 target), deployed to the GX device, restarted `dbus-fronius`.
  - After fix: `LimiterSupported` correctly reads `0`.